### PR TITLE
added quick unicode fix for multithreaded mode

### DIFF
--- a/src/textutil.jl
+++ b/src/textutil.jl
@@ -26,13 +26,16 @@ end
 function looped_word_iterator(f::IO, start_pos::Int64, end_pos::Int64)
   function producer()
     while true
-      w = readuntil(f, ' ')
-      if length(w) < 1 break end
-      w = w[1:end-1]
-      if !adagram_isblank(w)
-        produce(w)
+      try
+        w = readuntil(f, ' ')
+        if length(w) < 1 break end
+        w = w[1:end-1]
+        if !adagram_isblank(w)
+          produce(w)
+        end
+        if position(f) >= end_pos seek(f, start_pos) end
+      catch UnicodeError
       end
-      if position(f) >= end_pos seek(f, start_pos) end
     end
   end
 


### PR DESCRIPTION
If you seek() an utf-8 file to incorrect position (inside of utf-8 character), the UnicodeError is the next thing you see when you try to readuntil() starting from it. But before raising exception readuntil() advances pointer to safe position, so subsequent calls to readuntil() will be ok, so we just need to catch this exception silently. Maybe there is more elegant way to accomplish this?
