### PR TITLE
Update to Julia 0.6 - no longer need Devectorize.jl

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
-Devectorize
+julia 0.6
 ArrayViews
 ArgParse

--- a/src/AdaGram.jl
+++ b/src/AdaGram.jl
@@ -1,7 +1,6 @@
 module AdaGram
 
 using ArrayViews
-using Devectorize
 
 sigmoid(x) = 1. / (1. + exp(-x))
 log_sigmoid(x) = -log(1. + exp(-x))
@@ -51,7 +50,7 @@ function shared_rand{T}(dims::Tuple, norm::T)
 			chunk = localindexes(S)
 			chunk_size = length(chunk)
 			data = rand(chunk_size)
-			@devec data = (data - 0.5) ./ norm
+			data = (data - 0.5) ./ norm
 			S[chunk] = data
 		end)
 	return S


### PR DESCRIPTION
Vector operations in Julia 0.6 achieve loop performance without the additional dependencies. 

Devectorize doesn't work on Julia 0.6 because it uses deprecated string types