### PR TITLE
Distance calc

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -185,7 +185,7 @@ function vec(vm::VectorModel, dict::Dictionary, w::AbstractString, s::Integer)
 	return vec(vm, dict.word2id[w], s)
 end
 
-function distance(vm::VectorModel, dict::Dictionary, w1::AbstractString, s1::Integer, w2::AbstractString, s2::Integer)
+function similarity(vm::VectorModel, dict::Dictionary, w1::AbstractString, s1::Integer, w2::AbstractString, s2::Integer)
 	v1 = dict.word2id[w1]
 	v2 = dict.word2id[w2]
 	sense_vec1 = vec(vm, v1, s1)
@@ -270,4 +270,4 @@ export nearest_neighbors
 export disambiguate
 export pi, write_extended
 export cos_dist, preprocess, read_word2vec, write_word2vec
-export distance
+export similarity

--- a/src/util.jl
+++ b/src/util.jl
@@ -185,6 +185,14 @@ function vec(vm::VectorModel, dict::Dictionary, w::AbstractString, s::Integer)
 	return vec(vm, dict.word2id[w], s)
 end
 
+function distance(vm::VectorModel, dict::Dictionary, w1::AbstractString, s1::Integer, w2::AbstractString, s2::Integer)
+	v1 = dict.word2id[w1]
+	v2 = dict.word2id[w2]
+	sense_vec1 = vec(vm, v1, s1)
+	sense_vec2 = vec(vm, v2, s2)
+	return dot(sense_vec1, sense_vec2)
+end
+
 function nearest_neighbors(vm::VectorModel, dict::Dictionary, word::DenseArray{Tsf},
 		K::Integer=10; exclude::Array{Tuple{Int32, Int64}}=Array(Tuple{Int32, Int64}, 0),
 		min_count::Float64=1.)
@@ -262,3 +270,4 @@ export nearest_neighbors
 export disambiguate
 export pi, write_extended
 export cos_dist, preprocess, read_word2vec, write_word2vec
+export distance


### PR DESCRIPTION
Added a function to calculate similarity between 2 sense vectors.
cos_distance does almost this, but it needs the raw vectors as input.

similarity(vm::VectorModel, dict::Dictionary, w1::AbstractString, s1::Integer, w2::AbstractString, s2::Integer) takes the words as strings, as well as which senses (as integers) to calculate their similarity.