### PR TITLE
Change the condition inside @assert

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -200,7 +200,7 @@ function nearest_neighbors(vm::VectorModel, dict::Dictionary, word::DenseArray{T
 			end
 			in_vs = view(vm.In, :, s, v)
 			sim[s, v] = dot(in_vs, word) / norm(in_vs)
-			@assert(!isnan(sim[s, v]), "NaN found, $s, $(dict.id2word[v])")
+			@assert(isnan(sim[s, v]), "NaN found, $s, $(dict.id2word[v])")
 		end
 	end
 	for (v, s) in exclude


### PR DESCRIPTION
AssertionError was outputted when I tried to use nearest_neighbors function.
I though that AssertionError should be shown if the sim[s, v] is nan.
I'm not familiar with julia, so please ignore this pr if I'm saying something wrong.

I was wrong...